### PR TITLE
MaterialSpinner supporting input hint

### DIFF
--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -29,5 +29,7 @@
       <enum name="wrap_content" value="-2"/>
     </attr>
     <attr name="ms_background_selector" format="integer"/>
+    <attr name="ms_hint" format="string" />
+    <attr name="ms_hint_color" format="color"/>
   </declare-styleable>
 </resources>


### PR DESCRIPTION
# A MaterialSpinner supporting an input hint.

Input hint similiar to the EditText input hint concept.

## This defines:
+ ms_hint for the hint text
+ ms_hint_color for the color of the hint text's color