### PR TITLE
Fix for two-item spinners that make use of the adapter wrapper

### DIFF
--- a/library/src/main/java/com/jaredrummler/materialspinner/MaterialSpinnerAdapterWrapper.java
+++ b/library/src/main/java/com/jaredrummler/materialspinner/MaterialSpinnerAdapterWrapper.java
@@ -32,11 +32,15 @@ final class MaterialSpinnerAdapterWrapper extends MaterialSpinnerBaseAdapter {
   }
 
   @Override public int getCount() {
-    return listAdapter.getCount() - 1;
+    int size = listAdapter.getCount();
+    if (size == 1 || isHintEnabled()) return size;
+    return size - 1;
   }
 
   @Override public Object getItem(int position) {
-    if (position >= getSelectedIndex()) {
+    if (isHintEnabled()) {
+      return listAdapter.getItem(position);
+    } else if (position >= getSelectedIndex() && listAdapter.getCount() != 1) {
       return listAdapter.getItem(position + 1);
     } else {
       return listAdapter.getItem(position);
@@ -49,8 +53,8 @@ final class MaterialSpinnerAdapterWrapper extends MaterialSpinnerBaseAdapter {
 
   @Override public List<Object> getItems() {
     List<Object> items = new ArrayList<>();
-    for (int i = 0; i < getCount(); i++) {
-      items.add(getItem(i));
+    for (int i = 0; i < listAdapter.getCount(); i++) {
+      items.add(listAdapter.getItem(i));
     }
     return items;
   }


### PR DESCRIPTION
Quick mostly copy-paste from MaterialSpinnerAdapter. Unsure whether isHintEnabled() has any use case with custom adapters so those cases are untested.