### PR TITLE
Enable OnItemSelectedListner for setSelectedIndex method

### DIFF
--- a/demo/src/main/java/com/jaredrummler/materialspinner/example/MainActivity.java
+++ b/demo/src/main/java/com/jaredrummler/materialspinner/example/MainActivity.java
@@ -65,12 +65,17 @@ public class MainActivity extends AppCompatActivity {
 
     MaterialSpinner spinner = (MaterialSpinner) findViewById(R.id.spinner);
     spinner.setItems(ANDROID_VERSIONS);
+
     spinner.setOnItemSelectedListener(new MaterialSpinner.OnItemSelectedListener<String>() {
 
       @Override public void onItemSelected(MaterialSpinner view, int position, long id, String item) {
         Snackbar.make(view, "Clicked " + item, Snackbar.LENGTH_LONG).show();
       }
     });
+
+    // if listener enabled is true You must declare it after setOnItemSelectedListener()
+    spinner.setSelectedIndex(0,true);
+
     spinner.setOnNothingSelectedListener(new MaterialSpinner.OnNothingSelectedListener() {
 
       @Override public void onNothingSelected(MaterialSpinner spinner) {

--- a/library/src/main/java/com/jaredrummler/materialspinner/MaterialSpinner.java
+++ b/library/src/main/java/com/jaredrummler/materialspinner/MaterialSpinner.java
@@ -359,13 +359,32 @@ public class MaterialSpinner extends TextView {
    * Set the default spinner item using its index
    *
    * @param position the item's position
+   * @param  listenerEnabled if user set true then listener enable at the first user must declare it after
+   * setItemSelectedListener and if that is false then itemSelectedListener not enabled at the first
    */
-  public void setSelectedIndex(int position) {
+  public void setSelectedIndex(int position,boolean listenerEnabled) {
     if (adapter != null) {
       if (position >= 0 && position <= adapter.getCount()) {
         adapter.notifyItemSelected(position);
         selectedIndex = position;
         setText(adapter.get(position).toString());
+
+        if(listenerEnabled)
+        {
+
+          if(onItemSelectedListener != null)
+          {
+
+            onItemSelectedListener.onItemSelected(MaterialSpinner.this, position,getId(),adapter.get(position));
+          }
+
+          else {
+
+            throw new IllegalStateException("Make listenerEnabled false or declare setSelectedIndex() after setOnItemSelectedListener()");
+          }
+
+        }
+
       } else {
         throw new IllegalArgumentException("Position must be lower than adapter count!");
       }


### PR DESCRIPTION
When We declare spinner.setSelectedIndex() item selected listener not  has any reaction and not called. I add this feature that called this listener at the first.:)